### PR TITLE
avoid error "global name 'Datastream' is not defined" and use UTC time i...

### DIFF
--- a/examples/currentcost2xively.py
+++ b/examples/currentcost2xively.py
@@ -31,10 +31,10 @@ def main(device='/dev/ttyUSB0'):
     api = xively.XivelyAPIClient(XIVELY_API_KEY)
     feed = api.feeds.get(XIVELY_FEED_ID)
     for at, watts, tmpr in read_data(open(device, errors='ignore')):
-        now = datetime.datetime.now()
+        now = datetime.datetime.utcnow()
         feed.datastreams = [
-            Datastream(id='tmpr', current_value=tmpr, at=now),
-            Datastream(id='watts', current_value=watts, at=now),
+            xively.Datastream(id='tmpr', current_value=tmpr, at=now),
+            xively.Datastream(id='watts', current_value=watts, at=now),
         ]
         feed.update()
         print(at, watts, tmpr)


### PR DESCRIPTION
Hi,

Just a little patch for the example "currentcost2xively.py" because i have some issues with it :
- add path to xively module for Datastream.
- use UTC time for the update.

Have a nice day.

Loic Lefebvre
